### PR TITLE
desc: meta data clean-up, fix: Sliver rule FPs with CloudFoundry, refactor: avoid AV detection

### DIFF
--- a/YARA/CobaltStrike/CobaltStrike__Resources_Artifact32_and_Resources_Dropper_v1_45_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Artifact32_and_Resources_Dropper_v1_45_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Artifact32_and_Resources_Dropper_v1_49_to_v3_14
+rule CobaltStrike_Resources_Artifact32_and_Resources_Dropper_v1_49_to_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact32{.exe,.dll,big.exe,big.dll} and resources/dropper.exe signature for versions 1.49 to 3.14"
-		rs1 = "40fc605a8b95bbd79a3bd7d9af73fbeebe3fada577c99e7a111f6168f6a0d37a"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact32{.exe,.dll,big.exe,big.dll} and resources/dropper.exe signature for versions 1.49 to 3.14"
+		hash =  "40fc605a8b95bbd79a3bd7d9af73fbeebe3fada577c99e7a111f6168f6a0d37a"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
   // Decoder function for the embedded payload
@@ -29,12 +31,14 @@ rule CobaltStrike__Resources_Artifact32_and_Resources_Dropper_v1_49_to_v3_14
 		any of them
 }
 
-rule CobaltStrike__Resources_Artifact32_v3_1_and_v3_2
+rule CobaltStrike_Resources_Artifact32_v3_1_and_v3_2
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact32{.dll,.exe,svc.exe,big.exe,big.dll,bigsvc.exe} and resources/artifact32uac(alt).dll signature for versions 3.1 and 3.2"
-		rs1 = "4f14bcd7803a8e22e81e74d6061d0df9e8bac7f96f1213d062a29a8523ae4624"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact32{.dll,.exe,svc.exe,big.exe,big.dll,bigsvc.exe} and resources/artifact32uac(alt).dll signature for versions 3.1 and 3.2"
+		hash =  "4f14bcd7803a8e22e81e74d6061d0df9e8bac7f96f1213d062a29a8523ae4624"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*
@@ -55,12 +59,14 @@ rule CobaltStrike__Resources_Artifact32_v3_1_and_v3_2
 		all of them
 }
 
-rule CobaltStrike__Resources_Artifact32_v3_14_to_v4_x
+rule CobaltStrike_Resources_Artifact32_v3_14_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact32{.dll,.exe,big.exe,big.dll,bigsvc.exe} signature for versions 3.14 to 4.x and resources/artifact32svc.exe for 3.14 to 4.x and resources/artifact32uac.dll for v3.14 and v4.0"
-		rs1 = "888bae8d89c03c1d529b04f9e4a051140ce3d7b39bc9ea021ad9fc7c9f467719"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact32{.dll,.exe,big.exe,big.dll,bigsvc.exe} signature for versions 3.14 to 4.x and resources/artifact32svc.exe for 3.14 to 4.x and resources/artifact32uac.dll for v3.14 and v4.0"
+		hash =  "888bae8d89c03c1d529b04f9e4a051140ce3d7b39bc9ea021ad9fc7c9f467719"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Artifact32svc_Exe_v1_49_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Artifact32svc_Exe_v1_49_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Artifact32svc_Exe_v1_49_to_v3_14
+rule CobaltStrike_Resources_Artifact32svc_Exe_v1_49_to_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact32svc(big).exe and resources/artifact32uac(alt).exe signature for versions v1.49 to v3.14"
-		rs1 = "323ddf9623368b550def9e8980fde0557b6fe2dcd945fda97aa3b31c6c36d682"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact32svc(big).exe and resources/artifact32uac(alt).exe signature for versions v1.49 to v3.14"
+		hash =  "323ddf9623368b550def9e8980fde0557b6fe2dcd945fda97aa3b31c6c36d682"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*
@@ -48,12 +50,14 @@ rule CobaltStrike__Resources_Artifact32svc_Exe_v1_49_to_v3_14
 		any of them
 }
 
-rule CobaltStrike__Resources_Artifact32svc_Exe_v3_1_v3_2_v3_14_and_v4_x
+rule CobaltStrike_Resources_Artifact32svc_Exe_v3_1_v3_2_v3_14_and_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact32svc(big).exe signature for versions 3.1 and 3.2 (with overlap with v3.14 through v4.x)"
-		rs1 = "871390255156ce35221478c7837c52d926dfd581173818620b738b4b029e6fd9"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact32svc(big).exe signature for versions 3.1 and 3.2 (with overlap with v3.14 through v4.x)"
+		hash =  "871390255156ce35221478c7837c52d926dfd581173818620b738b4b029e6fd9"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Artifact64_v1_49_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Artifact64_v1_49_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Artifact64_v1_49_v2_x_v3_0_v3_3_thru_v3_14
+rule CobaltStrike_Resources_Artifact64_v1_49_v2_x_v3_0_v3_3_thru_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact64{.dll,.exe,big.exe,big.dll,bigsvc.exe,big.x64.dll} and resources/rtifactuac(alt)64.dll signature for versions v1.49, v2.x, v3.0, and v3.3 through v3.14"
-		rs1 = "9ec57d306764517b5956b49d34a3a87d4a6b26a2bb3d0fdb993d055e0cc9920d"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact64{.dll,.exe,big.exe,big.dll,bigsvc.exe,big.x64.dll} and resources/rtifactuac(alt)64.dll signature for versions v1.49, v2.x, v3.0, and v3.3 through v3.14"
+		hash =  "9ec57d306764517b5956b49d34a3a87d4a6b26a2bb3d0fdb993d055e0cc9920d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*
@@ -51,12 +53,14 @@ rule CobaltStrike__Resources_Artifact64_v1_49_v2_x_v3_0_v3_3_thru_v3_14
 		$a
 }
 
-rule CobaltStrike__Resources_Artifact64_v3_1_v3_2_v3_14_and_v4_0
+rule CobaltStrike_Resources_Artifact64_v3_1_v3_2_v3_14_and_v4_0
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact64{svcbig.exe,.dll,big.dll,svc.exe} and resources/artifactuac(big)64.dll signature for versions 3.14 to 4.x and resources/artifact32svc.exe for 3.14 to 4.x"
-		rs1 = "2e7a39bd6ac270f8f548855b97c4cef2c2ce7f54c54dd4d1aa0efabeecf3ba90"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact64{svcbig.exe,.dll,big.dll,svc.exe} and resources/artifactuac(big)64.dll signature for versions 3.14 to 4.x and resources/artifact32svc.exe for 3.14 to 4.x"
+		hash =  "2e7a39bd6ac270f8f548855b97c4cef2c2ce7f54c54dd4d1aa0efabeecf3ba90"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*
@@ -79,12 +83,14 @@ rule CobaltStrike__Resources_Artifact64_v3_1_v3_2_v3_14_and_v4_0
 		$decoderFunction
 }
 
-rule CobaltStrike__Resources_Artifact64_v3_14_to_v4_x
+rule CobaltStrike_Resources_Artifact64_v3_14_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/artifact64{.exe,.dll,svc.exe,svcbig.exe,big.exe,big.dll,.x64.dll,big.x64.dll} and resource/artifactuac(alt)64.exe signature for versions v3.14 through v4.x"
-		rs1 = "decfcca0018f2cec4a200ea057c804bb357300a67c6393b097d52881527b1c44"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/artifact64{.exe,.dll,svc.exe,svcbig.exe,big.exe,big.dll,.x64.dll,big.x64.dll} and resource/artifactuac(alt)64.exe signature for versions v3.14 through v4.x"
+		hash =  "decfcca0018f2cec4a200ea057c804bb357300a67c6393b097d52881527b1c44"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Beacon_Dll_All_Versions_MemEnabled.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Beacon_Dll_All_Versions_MemEnabled.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_44
+rule CobaltStrike_Resources_Beacon_Dll_v1_44
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.44"
-    rs1 ="75102e8041c58768477f5f982500da7e03498643b6ece86194f4b3396215f9c2"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.44"
+    hash = "75102e8041c58768477f5f982500da7e03498643b6ece86194f4b3396215f9c2"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -46,12 +48,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_44
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_45
+rule CobaltStrike_Resources_Beacon_Dll_v1_45
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.45"
-    rs1 ="1a92b2024320f581232f2ba1e9a11bef082d5e9723429b3e4febb149458d1bb1"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.45"
+    hash = "1a92b2024320f581232f2ba1e9a11bef082d5e9723429b3e4febb149458d1bb1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -79,12 +83,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_45
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_46
+rule CobaltStrike_Resources_Beacon_Dll_v1_46
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.46"
-    rs1 ="44e34f4024878024d4804246f57a2b819020c88ba7de160415be38cd6b5e2f76"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.46"
+    hash = "44e34f4024878024d4804246f57a2b819020c88ba7de160415be38cd6b5e2f76"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -108,12 +114,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_46
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_47
+rule CobaltStrike_Resources_Beacon_Dll_v1_47
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.47"
-    rs1 ="8ff6dc80581804391183303bb39fca2a5aba5fe13d81886ab21dbd183d536c8d"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.47"
+    hash = "8ff6dc80581804391183303bb39fca2a5aba5fe13d81886ab21dbd183d536c8d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -135,12 +143,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_47
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_48
+rule CobaltStrike_Resources_Beacon_Dll_v1_48
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.48"
-    rs1 ="dd4e445572cd5e32d7e9cc121e8de337e6f19ff07547e3f2c6b7fce7eafd15e4"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.48"
+    hash = "dd4e445572cd5e32d7e9cc121e8de337e6f19ff07547e3f2c6b7fce7eafd15e4"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -167,12 +177,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_48
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v1_49
+rule CobaltStrike_Resources_Beacon_Dll_v1_49
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 1.49"
-    rs1 ="52b4bd87e21ee0cbaaa0fc007fd3f894c5fc2c4bae5cbc2a37188de3c2c465fe"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 1.49"
+    hash = "52b4bd87e21ee0cbaaa0fc007fd3f894c5fc2c4bae5cbc2a37188de3c2c465fe"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -198,12 +210,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v1_49
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v2_0_49
+rule CobaltStrike_Resources_Beacon_Dll_v2_0_49
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Version 2.0.49"
-    rs1 ="ed08c1a21906e313f619adaa0a6e5eb8120cddd17d0084a30ada306f2aca3a4e"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Version 2.0.49"
+    hash = "ed08c1a21906e313f619adaa0a6e5eb8120cddd17d0084a30ada306f2aca3a4e"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -228,13 +242,15 @@ rule CobaltStrike__Resources_Beacon_Dll_v2_0_49
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v2_1_and_v2_2
+rule CobaltStrike_Resources_Beacon_Dll_v2_1_and_v2_2
 {
   // v2.1 and v2.2 use the exact same beacon binary (matching hashes)
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 2.1 and 2.2"
-    rs1 ="ae7a1d12e98b8c9090abe19bcaddbde8db7b119c73f7b40e76cdebb2610afdc2"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 2.1 and 2.2"
+    hash = "ae7a1d12e98b8c9090abe19bcaddbde8db7b119c73f7b40e76cdebb2610afdc2"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -259,12 +275,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v2_1_and_v2_2
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v2_3
+rule CobaltStrike_Resources_Beacon_Dll_v2_3
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 2.3"
-    rs1 ="00dd982cb9b37f6effb1a5a057b6571e533aac5e9e9ee39a399bb3637775ff83"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 2.3"
+    hash = "00dd982cb9b37f6effb1a5a057b6571e533aac5e9e9ee39a399bb3637775ff83"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -289,12 +307,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v2_3
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v2_4
+rule CobaltStrike_Resources_Beacon_Dll_v2_4
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 2.4"
-    rs1 ="78c6f3f2b80e6140c4038e9c2bcd523a1b205d27187e37dc039ede4cf560beed"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 2.4"
+    hash = "78c6f3f2b80e6140c4038e9c2bcd523a1b205d27187e37dc039ede4cf560beed"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -319,12 +339,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v2_4
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v2_5
+rule CobaltStrike_Resources_Beacon_Dll_v2_5
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 2.5"
-    rs1 ="d99693e3e521f42d19824955bef0cefb79b3a9dbf30f0d832180577674ee2b58"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 2.5"
+    hash = "d99693e3e521f42d19824955bef0cefb79b3a9dbf30f0d832180577674ee2b58"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -349,12 +371,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v2_5
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_0
+rule CobaltStrike_Resources_Beacon_Dll_v3_0
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.0"
-    rs1 ="30251f22df7f1be8bc75390a2f208b7514647835f07593f25e470342fd2e3f52"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.0"
+    hash = "30251f22df7f1be8bc75390a2f208b7514647835f07593f25e470342fd2e3f52"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -379,12 +403,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_0
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_1
+rule CobaltStrike_Resources_Beacon_Dll_v3_1
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.1"
-    rs1 ="4de723e784ef4e1633bbbd65e7665adcfb03dd75505b2f17d358d5a40b7f35cf"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.1"
+    hash = "4de723e784ef4e1633bbbd65e7665adcfb03dd75505b2f17d358d5a40b7f35cf"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   // v3.1 and v3.2 share the same C2 handler code. We are using a function that
   // is not included in v3.2 to mark the v3.1 version along with the decoder
@@ -434,13 +460,15 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_1
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_2
+rule CobaltStrike_Resources_Beacon_Dll_v3_2
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.2"
-    rs1 ="b490eeb95d150530b8e155da5d7ef778543836a03cb5c27767f1ae4265449a8d"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.2"
+    hash = "b490eeb95d150530b8e155da5d7ef778543836a03cb5c27767f1ae4265449a8d"
     rs2 ="a93647c373f16d61c38ba6382901f468247f12ba8cbe56663abb2a11ff2a5144"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -499,12 +527,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_2
     $version_sig and $decoder and not $version3_1_sig
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_3
+rule CobaltStrike_Resources_Beacon_Dll_v3_3
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.3"
-    rs1 ="158dba14099f847816e2fc22f254c60e09ac999b6c6e2ba6f90c6dd6d937bc42"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.3"
+    hash = "158dba14099f847816e2fc22f254c60e09ac999b6c6e2ba6f90c6dd6d937bc42"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -529,12 +559,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_3
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_4
+rule CobaltStrike_Resources_Beacon_Dll_v3_4
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.4"
-    rs1 ="5c40bfa04a957d68a095dd33431df883e3a075f5b7dea3e0be9834ce6d92daa3"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.4"
+    hash = "5c40bfa04a957d68a095dd33431df883e3a075f5b7dea3e0be9834ce6d92daa3"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -559,13 +591,15 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_4
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_5_hf1_and_3_5_1
+rule CobaltStrike_Resources_Beacon_Dll_v3_5_hf1_and_3_5_1
 {
   // Version 3.5-hf1 and 3.5.1 use the exact same beacon binary (same hash)
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.5-hf1 and 3.5.1 (3.5.x)"
-    rs1 ="c78e70cd74f4acda7d1d0bd85854ccacec79983565425e98c16a9871f1950525"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.5-hf1 and 3.5.1 (3.5.x)"
+    hash = "c78e70cd74f4acda7d1d0bd85854ccacec79983565425e98c16a9871f1950525"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -590,12 +624,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_5_hf1_and_3_5_1
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_6
+rule CobaltStrike_Resources_Beacon_Dll_v3_6
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.6"
-    rs1 ="495a744d0a0b5f08479c53739d08bfbd1f3b9818d8a9cbc75e71fcda6c30207d"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.6"
+    hash = "495a744d0a0b5f08479c53739d08bfbd1f3b9818d8a9cbc75e71fcda6c30207d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -620,12 +656,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_6
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_7
+rule CobaltStrike_Resources_Beacon_Dll_v3_7
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.7"
-    rs1 ="f18029e6b12158fb3993f4951dab2dc6e645bb805ae515d205a53a1ef41ca9b2"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.7"
+    hash = "f18029e6b12158fb3993f4951dab2dc6e645bb805ae515d205a53a1ef41ca9b2"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -650,12 +688,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_7
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_8
+rule CobaltStrike_Resources_Beacon_Dll_v3_8
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.8"
-    rs1 ="67b6557f614af118a4c409c992c0d9a0cc800025f77861ecf1f3bbc7c293d603"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.8"
+    hash = "67b6557f614af118a4c409c992c0d9a0cc800025f77861ecf1f3bbc7c293d603"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -696,12 +736,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_8
 
 */
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_11
+rule CobaltStrike_Resources_Beacon_Dll_v3_11
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.11"
-    rs1 ="2428b93464585229fd234677627431cae09cfaeb1362fe4f648b8bee59d68f29"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.11"
+    hash = "2428b93464585229fd234677627431cae09cfaeb1362fe4f648b8bee59d68f29"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   // Original version from April 9, 2018
   strings:
@@ -727,13 +769,15 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_11
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_11_bugfix_and_v3_12
+rule CobaltStrike_Resources_Beacon_Dll_v3_11_bugfix_and_v3_12
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.11-bugfix and 3.12"
-    rs1 ="5912c96fffeabb2c5c5cdd4387cfbfafad5f2e995f310ace76ca3643b866e3aa"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.11-bugfix and 3.12"
+    hash = "5912c96fffeabb2c5c5cdd4387cfbfafad5f2e995f310ace76ca3643b866e3aa"
     rs2 ="4476a93abe48b7481c7b13dc912090b9476a2cdf46a1c4287b253098e3523192"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   // Covers both 3.11 (bug fix form May 25, 2018) and v3.12
   strings:
@@ -759,12 +803,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_11_bugfix_and_v3_12
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_13
+rule CobaltStrike_Resources_Beacon_Dll_v3_13
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.13"
-    rs1 ="362119e3bce42e91cba662ea80f1a7957a5c2b1e92075a28352542f31ac46a0c"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.13"
+    hash = "362119e3bce42e91cba662ea80f1a7957a5c2b1e92075a28352542f31ac46a0c"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -789,13 +835,15 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_13
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_Dll_v3_14
+rule CobaltStrike_Resources_Beacon_Dll_v3_14
 {
   meta:
-    desc="Cobalt Strike's resources/beacon.dll Versions 3.14"
-    rs1 ="254c68a92a7108e8c411c7b5b87a2f14654cd9f1324b344f036f6d3b6c7accda"
+    description = "Cobalt Strike's resources/beacon.dll Versions 3.14"
+    hash = "254c68a92a7108e8c411c7b5b87a2f14654cd9f1324b344f036f6d3b6c7accda"
     rs2 ="87b3eb55a346b52fb42b140c03ac93fc82f5a7f80697801d3f05aea1ad236730"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -817,12 +865,14 @@ rule CobaltStrike__Resources_Beacon_Dll_v3_14
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_Dll_v4_0_suspected
+rule CobaltStrike_Sleeve_Beacon_Dll_v4_0_suspected
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.dll Versions 4.0 (suspected, not confirmed)"
-    rs1 = "e2b2b72454776531bbc6a4a5dd579404250901557f887a6bccaee287ac71b248"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.dll Versions 4.0 (suspected, not confirmed)"
+    hash =  "e2b2b72454776531bbc6a4a5dd579404250901557f887a6bccaee287ac71b248"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -850,13 +900,15 @@ rule CobaltStrike__Sleeve_Beacon_Dll_v4_0_suspected
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_Dll_v4_1_and_v4_2
+rule CobaltStrike_Sleeve_Beacon_Dll_v4_1_and_v4_2
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.dll Versions 4.1 and 4.2"
-    rs1 ="daa42f4380cccf8729129768f3588bb98e4833b0c40ad0620bb575b5674d5fc3"
+    description = "Cobalt Strike's sleeve/beacon.dll Versions 4.1 and 4.2"
+    hash = "daa42f4380cccf8729129768f3588bb98e4833b0c40ad0620bb575b5674d5fc3"
     rs2 ="9de55f27224a4ddb6b2643224a5da9478999c7b2dea3a3d6b3e1808148012bcf"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -881,13 +933,15 @@ rule CobaltStrike__Sleeve_Beacon_Dll_v4_1_and_v4_2
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_Dll_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_Beacon_Dll_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.dll Versions 4.3 and 4.4"
-    rs1 ="51490c01c72c821f476727c26fbbc85bdbc41464f95b28cdc577e5701790845f"
+    description = "Cobalt Strike's sleeve/beacon.dll Versions 4.3 and 4.4"
+    hash = "51490c01c72c821f476727c26fbbc85bdbc41464f95b28cdc577e5701790845f"
     rs2 ="78a6fbefa677eeee29d1af4a294ee57319221b329a2fe254442f5708858b37dc"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -912,12 +966,14 @@ rule CobaltStrike__Sleeve_Beacon_Dll_v4_3_v4_4_v4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_Dll_v4_7_suspected
+rule CobaltStrike_Sleeve_Beacon_Dll_v4_7_suspected
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.dll Versions 4.7 (suspected, not confirmed)"
-    rs1 = "da9e91b3d8df3d53425dd298778782be3bdcda40037bd5c92928395153160549"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.dll Versions 4.7 (suspected, not confirmed)"
+    hash =  "da9e91b3d8df3d53425dd298778782be3bdcda40037bd5c92928395153160549"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
 
@@ -970,12 +1026,14 @@ rule CobaltStrike__Sleeve_Beacon_Dll_v4_7_suspected
 */
 
 
-rule CobaltStrike__Resources_Beacon_x64_v3_2
+rule CobaltStrike_Resources_Beacon_x64_v3_2
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.2"
-    rs1 = "5993a027f301f37f3236551e6ded520e96872723a91042bfc54775dcb34c94a1"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.2"
+    hash =  "5993a027f301f37f3236551e6ded520e96872723a91042bfc54775dcb34c94a1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1009,12 +1067,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_2
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_3
+rule CobaltStrike_Resources_Beacon_x64_v3_3
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.3"
-    rs1 = "7b00721efeff6ed94ab108477d57b03022692e288cc5814feb5e9d83e3788580"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.3"
+    hash =  "7b00721efeff6ed94ab108477d57b03022692e288cc5814feb5e9d83e3788580"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1048,12 +1108,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_3
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_4
+rule CobaltStrike_Resources_Beacon_x64_v3_4
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.4"
-    rs1 = "5a4d48c2eda8cda79dc130f8306699c8203e026533ce5691bf90363473733bf0"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.4"
+    hash =  "5a4d48c2eda8cda79dc130f8306699c8203e026533ce5691bf90363473733bf0"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1085,12 +1147,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_4
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_5_hf1_and_v3_5_1
+rule CobaltStrike_Resources_Beacon_x64_v3_5_hf1_and_v3_5_1
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.5-hf1 and 3.5.1"
-    rs1 = "934134ab0ee65ec76ae98a9bb9ad0e9571d80f4bf1eb3491d58bacf06d42dc8d"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.5-hf1 and 3.5.1"
+    hash =  "934134ab0ee65ec76ae98a9bb9ad0e9571d80f4bf1eb3491d58bacf06d42dc8d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1124,12 +1188,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_5_hf1_and_v3_5_1
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_6
+rule CobaltStrike_Resources_Beacon_x64_v3_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.6"
-    rs1 = "92b0a4aec6a493bcb1b72ce04dd477fd1af5effa0b88a9d8283f26266bb019a1"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.6"
+    hash =  "92b0a4aec6a493bcb1b72ce04dd477fd1af5effa0b88a9d8283f26266bb019a1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1166,12 +1232,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_6
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_7
+rule CobaltStrike_Resources_Beacon_x64_v3_7
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.7"
-    rs1 = "81296a65a24c0f6f22208b0d29e7bb803569746ce562e2fa0d623183a8bcca60"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.7"
+    hash =  "81296a65a24c0f6f22208b0d29e7bb803569746ce562e2fa0d623183a8bcca60"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1205,12 +1273,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_7
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_8
+rule CobaltStrike_Resources_Beacon_x64_v3_8
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.8"
-    rs1 = "547d44669dba97a32cb9e95cfb8d3cd278e00599e6a11080df1a9d09226f33ae"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.8"
+    hash =  "547d44669dba97a32cb9e95cfb8d3cd278e00599e6a11080df1a9d09226f33ae"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1239,13 +1309,15 @@ rule CobaltStrike__Resources_Beacon_x64_v3_8
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_11
+rule CobaltStrike_Resources_Beacon_x64_v3_11
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.11 (two subversions)"
-    rs1 = "64007e104dddb6b5d5153399d850f1e1f1720d222bed19a26d0b1c500a675b1a"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.11 (two subversions)"
+    hash =  "64007e104dddb6b5d5153399d850f1e1f1720d222bed19a26d0b1c500a675b1a"
     rs2 = "815f313e0835e7fdf4a6d93f2774cf642012fd21ce870c48ff489555012e0047"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
 	
@@ -1293,12 +1365,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_11
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_12
+rule CobaltStrike_Resources_Beacon_x64_v3_12
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.12"
-    rs1 = "8a28b7a7e32ace2c52c582d0076939d4f10f41f4e5fa82551e7cc8bdbcd77ebc"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.12"
+    hash =  "8a28b7a7e32ace2c52c582d0076939d4f10f41f4e5fa82551e7cc8bdbcd77ebc"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1330,12 +1404,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_12
 }
 
 
-rule CobaltStrike__Resources_Beacon_x64_v3_13
+rule CobaltStrike_Resources_Beacon_x64_v3_13
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.13"
-    rs1 = "945e10dcd57ba23763481981c6035e0d0427f1d3ba71e75decd94b93f050538e"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.13"
+    hash =  "945e10dcd57ba23763481981c6035e0d0427f1d3ba71e75decd94b93f050538e"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1363,13 +1439,15 @@ rule CobaltStrike__Resources_Beacon_x64_v3_13
     all of them
 }
 
-rule CobaltStrike__Resources_Beacon_x64_v3_14
+rule CobaltStrike_Resources_Beacon_x64_v3_14
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 3.14"
-    rs1 = "297a8658aaa4a76599a7b79cb0da5b8aa573dd26c9e2c8f071e591200cf30c93"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 3.14"
+    hash =  "297a8658aaa4a76599a7b79cb0da5b8aa573dd26c9e2c8f071e591200cf30c93"
     rs2 = "39b9040e3dcd1421a36e02df78fe031cbdd2fb1a9083260b8aedea7c2bc406bf"
-    author = "gssincla@google.com"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
 
@@ -1399,12 +1477,14 @@ rule CobaltStrike__Resources_Beacon_x64_v3_14
 }
 
 
-rule CobaltStrike__Sleeve_Beacon_Dll_x86_v4_0_suspected
+rule CobaltStrike_Sleeve_Beacon_Dll_x86_v4_0_suspected
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 4.0 (suspected, not confirmed)"
-    rs1 = "55aa2b534fcedc92bb3da54827d0daaa23ece0f02a10eb08f5b5247caaa63a73"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 4.0 (suspected, not confirmed)"
+    hash =  "55aa2b534fcedc92bb3da54827d0daaa23ece0f02a10eb08f5b5247caaa63a73"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1434,12 +1514,14 @@ rule CobaltStrike__Sleeve_Beacon_Dll_x86_v4_0_suspected
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_x64_v4_1_and_v_4_2
+rule CobaltStrike_Sleeve_Beacon_x64_v4_1_and_v_4_2
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 4.1 and 4.2"
-    rs1 = "29ec171300e8d2dad2e1ca2b77912caf0d5f9d1b633a81bb6534acb20a1574b2"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 4.1 and 4.2"
+    hash =  "29ec171300e8d2dad2e1ca2b77912caf0d5f9d1b633a81bb6534acb20a1574b2"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -1470,12 +1552,14 @@ rule CobaltStrike__Sleeve_Beacon_x64_v4_1_and_v_4_2
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_x64_v4_3
+rule CobaltStrike_Sleeve_Beacon_x64_v4_3
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Version 4.3"
-    rs1 = "3ac9c3525caa29981775bddec43d686c0e855271f23731c376ba48761c27fa3d"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Version 4.3"
+    hash =  "3ac9c3525caa29981775bddec43d686c0e855271f23731c376ba48761c27fa3d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
   
@@ -1506,12 +1590,14 @@ rule CobaltStrike__Sleeve_Beacon_x64_v4_3
 }
 
 
-rule CobaltStrike__Sleeve_Beacon_x64_v4_4_v_4_5_and_v4_6
+rule CobaltStrike_Sleeve_Beacon_x64_v4_4_v_4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 4.4 through at least 4.6"
-    rs1 ="3280fec57b7ca94fd2bdb5a4ea1c7e648f565ac077152c5a81469030ccf6ab44"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 4.4 through at least 4.6"
+    hash = "3280fec57b7ca94fd2bdb5a4ea1c7e648f565ac077152c5a81469030ccf6ab44"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:
     /*
@@ -1541,12 +1627,14 @@ rule CobaltStrike__Sleeve_Beacon_x64_v4_4_v_4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_Beacon_x64_v4_5_variant
+rule CobaltStrike_Sleeve_Beacon_x64_v4_5_variant
 {
   meta:
-    desc="Cobalt Strike's sleeve/beacon.x64.dll Versions 4.5 (variant)"
-    rs1 = "8f0da7a45945b630cd0dfb5661036e365dcdccd085bc6cff2abeec6f4c9f1035"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/beacon.x64.dll Versions 4.5 (variant)"
+    hash =  "8f0da7a45945b630cd0dfb5661036e365dcdccd085bc6cff2abeec6f4c9f1035"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bind64_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bind64_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bind64_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Bind64_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/bind64.bin signature for versions v2.5 to v4.x"
-		rs1 = "5dd136f5674f66363ea6463fd315e06690d6cb10e3cc516f2d378df63382955d"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bind64.bin signature for versions v2.5 to v4.x"
+		hash =  "5dd136f5674f66363ea6463fd315e06690d6cb10e3cc516f2d378df63382955d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bind_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bind_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bind_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Bind_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/bind.bin signature for versions 2.5 to 4.x"
-		rs1 = "3727542c0e3c2bf35cacc9e023d1b2d4a1e9e86ee5c62ee5b66184f46ca126d1"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bind.bin signature for versions 2.5 to 4.x"
+		hash =  "3727542c0e3c2bf35cacc9e023d1b2d4a1e9e86ee5c62ee5b66184f46ca126d1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Browserpivot_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_Dll_v4_0_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Browserpivot_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_Dll_v4_0_to_v4_x.yara
@@ -17,9 +17,11 @@
 rule  CobaltStrike__Resources_Browserpivot_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_Dll_v4_0_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/browserpivot.bin from v1.48 to v3.14 and sleeve/browserpivot.dll from v4.0 to at least v4.4"
-		rs1 = "12af9f5a7e9bfc49c82a33d38437e2f3f601639afbcdc9be264d3a8d84fd5539"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/browserpivot.bin from v1.48 to v3.14 and sleeve/browserpivot.dll from v4.0 to at least v4.4"
+		hash =  "12af9f5a7e9bfc49c82a33d38437e2f3f601639afbcdc9be264d3a8d84fd5539"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Browserpivot_x64_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_x64_Dll_v4_0_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Browserpivot_x64_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_x64_Dll_v4_0_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Browserpivot_x64_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_x64_Dll_v4_0_to_v4_x
+rule CobaltStrike_Resources_Browserpivot_x64_Bin_v1_48_to_v3_14_and_Sleeve_Browserpivot_x64_Dll_v4_0_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/browserpivot.x64.bin from v1.48 to v3.14 and sleeve/browserpivot.x64.dll from v4.0 to at least v4.4"
-		rs1 = "0ad32bc4fbf3189e897805cec0acd68326d9c6f714c543bafb9bc40f7ac63f55"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/browserpivot.x64.bin from v1.48 to v3.14 and sleeve/browserpivot.x64.dll from v4.0 to at least v4.4"
+		hash =  "0ad32bc4fbf3189e897805cec0acd68326d9c6f714c543bafb9bc40f7ac63f55"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuac_Dll_v1_49_to_v3_14_and_Sleeve_Bypassuac_Dll_v4_0_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuac_Dll_v1_49_to_v3_14_and_Sleeve_Bypassuac_Dll_v4_0_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bypassuac_Dll_v1_49_to_v3_14_and_Sleeve_Bypassuac_Dll_v4_0_to_v4_x
+rule CobaltStrike_Resources_Bypassuac_Dll_v1_49_to_v3_14_and_Sleeve_Bypassuac_Dll_v4_0_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/bypassuac(-x86).dll from v1.49 to v3.14 (32-bit version) and sleeve/bypassuac.dll from v4.0 to at least v4.4"
-		rs1 = "91d12e1d09a642feedee5da966e1c15a2c5aea90c79ac796e267053e466df365"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bypassuac(-x86).dll from v1.49 to v3.14 (32-bit version) and sleeve/bypassuac.dll from v4.0 to at least v4.4"
+		hash =  "91d12e1d09a642feedee5da966e1c15a2c5aea90c79ac796e267053e466df365"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuac_x64_Dll_v3_3_to_v3_14_and_Sleeve_Bypassuac_x64_Dll_v4_0_and_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuac_x64_Dll_v3_3_to_v3_14_and_Sleeve_Bypassuac_x64_Dll_v4_0_and_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bypassuac_x64_Dll_v3_3_to_v3_14_and_Sleeve_Bypassuac_x64_Dll_v4_0_and_v4_x
+rule CobaltStrike_Resources_Bypassuac_x64_Dll_v3_3_to_v3_14_and_Sleeve_Bypassuac_x64_Dll_v4_0_and_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/bypassuac-x64.dll from v3.3 to v3.14 (64-bit version) and sleeve/bypassuac.x64.dll from v4.0 to at least v4.4"
-		rs1 = "9ecf56e9099811c461d592c325c65c4f9f27d947cbdf3b8ef8a98a43e583aecb"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bypassuac-x64.dll from v3.3 to v3.14 (64-bit version) and sleeve/bypassuac.x64.dll from v4.0 to at least v4.4"
+		hash =  "9ecf56e9099811c461d592c325c65c4f9f27d947cbdf3b8ef8a98a43e583aecb"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuactoken_Dll_v3_11_to_v3_14.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuactoken_Dll_v3_11_to_v3_14.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bypassuactoken_Dll_v3_11_to_v3_14
+rule CobaltStrike_Resources_Bypassuactoken_Dll_v3_11_to_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/bypassuactoken.dll from v3.11 to v3.14 (32-bit version)"
-		rs1 = "df1c7256dfd78506e38c64c54c0645b6a56fc56b2ffad8c553b0f770c5683070"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bypassuactoken.dll from v3.11 to v3.14 (32-bit version)"
+		hash =  "df1c7256dfd78506e38c64c54c0645b6a56fc56b2ffad8c553b0f770c5683070"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuactoken_x64_Dll_v3_11_to_v3_14.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Bypassuactoken_x64_Dll_v3_11_to_v3_14.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Bypassuactoken_x64_Dll_v3_11_to_v3_14
+rule CobaltStrike_Resources_Bypassuactoken_x64_Dll_v3_11_to_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/bypassuactoken.x64.dll from v3.11 to v3.14 (64-bit version)"
-		rs1 = "853068822bbc6b1305b2a9780cf1034f5d9d7127001351a6917f9dbb42f30d67"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/bypassuactoken.x64.dll from v3.11 to v3.14 (64-bit version)"
+		hash =  "853068822bbc6b1305b2a9780cf1034f5d9d7127001351a6917f9dbb42f30d67"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x
+rule CobaltStrike_Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/command.ps1 for versions 2.5 to v3.7 and resources/compress.ps1 from v3.8 to v4.x"
-		rs1 = "932dec24b3863584b43caf9bb5d0cfbd7ed1969767d3061a7abdc05d3239ed62"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/command.ps1 for versions 2.5 to v3.7 and resources/compress.ps1 from v3.8 to v4.x"
+		hash =  "932dec24b3863584b43caf9bb5d0cfbd7ed1969767d3061a7abdc05d3239ed62"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:		
     // the command.ps1 and compress.ps1 are the same file. Between v3.7 and v3.8 the file was renamed from command to compress.

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_v3_8_to_v4_x.yara
@@ -25,7 +25,7 @@ rule CobaltStrike_Resources_Command_Ps1_v2_5_to_v3_7_and_Resources_Compress_Ps1_
 
   strings:		
     // the command.ps1 and compress.ps1 are the same file. Between v3.7 and v3.8 the file was renamed from command to compress.
-    $ps1 = "$s=New-Object IO.MemoryStream(,[Convert]::FromBase64String(" nocase
+    $ps1 = "$s=New-Object \x49O.MemoryStream(,[Convert]::\x46romBase64String(" nocase
     $ps2 ="));IEX (New-Object IO.StreamReader(New-Object IO.Compression.GzipStream($s,[IO.Compression.CompressionMode]::Decompress))).ReadToEnd();" nocase
   
   condition:

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Covertvpn_Dll_v2_1_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Covertvpn_Dll_v2_1_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Covertvpn_Dll_v2_1_to_v4_x
+rule CobaltStrike_Resources_Covertvpn_Dll_v2_1_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/covertvpn.dll signature for version v2.2 to v4.4"
-		rs1 = "0a452a94d53e54b1df6ba02bc2f02e06d57153aad111171a94ec65c910d22dcf"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/covertvpn.dll signature for version v2.2 to v4.4"
+		hash =  "0a452a94d53e54b1df6ba02bc2f02e06d57153aad111171a94ec65c910d22dcf"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Covertvpn_injector_Exe_v1_44_to_v2_0_49.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Covertvpn_injector_Exe_v1_44_to_v2_0_49.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Covertvpn_injector_Exe_v1_44_to_v2_0_49
+rule CobaltStrike_Resources_Covertvpn_injector_Exe_v1_44_to_v2_0_49
 {
 	meta:
-		desc="Cobalt Strike's resources/covertvpn-injector.exe signature for version v1.44 to v2.0.49"
-		rs1 = "d741751520f46602f5a57d1ed49feaa5789115aeeba7fa4fc7cbb534ee335462"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/covertvpn-injector.exe signature for version v1.44 to v2.0.49"
+		hash =  "d741751520f46602f5a57d1ed49feaa5789115aeeba7fa4fc7cbb534ee335462"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Dnsstager_Bin_v1_47_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Dnsstager_Bin_v1_47_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Dnsstager_Bin_v1_47_through_v4_x
+rule CobaltStrike_Resources_Dnsstager_Bin_v1_47_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/dnsstager.bin signature for versions 1.47 to 4.x"
-		rs1 = "10f946b88486b690305b87c14c244d7bc741015c3fef1c4625fa7f64917897f1"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/dnsstager.bin signature for versions 1.47 to 4.x"
+		hash =  "10f946b88486b690305b87c14c244d7bc741015c3fef1c4625fa7f64917897f1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Elevate_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_Dll_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Elevate_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_Dll_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Elevate_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_Dll_v4_x
+rule CobaltStrike_Resources_Elevate_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_Dll_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/elevate.dll signature for v3.0 to v3.14 and sleeve/elevate.dll for v4.x"
-		rs1 = "6deeb2cafe9eeefe5fc5077e63cc08310f895e9d5d492c88c4e567323077aa2f"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/elevate.dll signature for v3.0 to v3.14 and sleeve/elevate.dll for v4.x"
+		hash =  "6deeb2cafe9eeefe5fc5077e63cc08310f895e9d5d492c88c4e567323077aa2f"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Elevate_X64_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_X64_Dll_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Elevate_X64_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_X64_Dll_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Elevate_X64_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_X64_Dll_v4_x
+rule CobaltStrike_Resources_Elevate_X64_Dll_v3_0_to_v3_14_and_Sleeve_Elevate_X64_Dll_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/elevate.x64.dll signature for v3.0 to v3.14 and sleeve/elevate.x64.dll for v4.x"
-		rs1 = "c3ee8a9181fed39cec3bd645b32b611ce98d2e84c5a9eff31a8acfd9c26410ec"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/elevate.x64.dll signature for v3.0 to v3.14 and sleeve/elevate.x64.dll for v4.x"
+		hash =  "c3ee8a9181fed39cec3bd645b32b611ce98d2e84c5a9eff31a8acfd9c26410ec"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Httpsstager64_Bin_v3_2_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Httpsstager64_Bin_v3_2_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Httpsstager64_Bin_v3_2_through_v4_x
+rule CobaltStrike_Resources_Httpsstager64_Bin_v3_2_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/httpsstager64.bin signature for versions v3.2 to v4.x"
-		rs1 = "109b8c55816ddc0defff360c93e8a07019ac812dd1a42209ea7e95ba79b5a573"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/httpsstager64.bin signature for versions v3.2 to v4.x"
+		hash =  "109b8c55816ddc0defff360c93e8a07019ac812dd1a42209ea7e95ba79b5a573"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Httpsstager_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Httpsstager_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Httpsstager_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Httpsstager_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/httpsstager.bin signature for versions 2.5 to 4.x"
-		rs1 = "5ebe813a4c899b037ac0ee0962a439833964a7459b7a70f275ac73ea475705b3"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/httpsstager.bin signature for versions 2.5 to 4.x"
+		hash =  "5ebe813a4c899b037ac0ee0962a439833964a7459b7a70f275ac73ea475705b3"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Httpstager64_Bin_v3_2_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Httpstager64_Bin_v3_2_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Httpstager64_Bin_v3_2_through_v4_x
+rule CobaltStrike_Resources_Httpstager64_Bin_v3_2_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/httpstager64.bin signature for versions v3.2 to v4.x"
-		rs1 = "ad93d1ee561bc25be4a96652942f698eac9b133d8b35ab7e7d3489a25f1d1e76"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/httpstager64.bin signature for versions v3.2 to v4.x"
+		hash =  "ad93d1ee561bc25be4a96652942f698eac9b133d8b35ab7e7d3489a25f1d1e76"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Httpstager_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Httpstager_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Httpstager_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Httpstager_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/httpstager.bin signature for versions 2.5 to 4.x"
-		rs1 = "a47569af239af092880751d5e7b68d0d8636d9f678f749056e702c9b063df256"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/httpstager.bin signature for versions 2.5 to 4.x"
+		hash =  "a47569af239af092880751d5e7b68d0d8636d9f678f749056e702c9b063df256"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Reverse64_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Reverse64_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Reverse64_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Reverse64_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/reverse64.bin signature for versions v2.5 to v4.x"
-		rs1 = "d2958138c1b7ef681a63865ec4a57b0c75cc76896bf87b21c415b7ec860397e8"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/reverse64.bin signature for versions v2.5 to v4.x"
+		hash =  "d2958138c1b7ef681a63865ec4a57b0c75cc76896bf87b21c415b7ec860397e8"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Reverse_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Reverse_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Reverse_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Reverse_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/reverse.bin signature for versions 2.5 to 4.x"
-		rs1 = "887f666d6473058e1641c3ce1dd96e47189a59c3b0b85c8b8fccdd41b84000c7"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/reverse.bin signature for versions 2.5 to 4.x"
+		hash =  "887f666d6473058e1641c3ce1dd96e47189a59c3b0b85c8b8fccdd41b84000c7"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Smbstager_Bin_v2_5_through_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Smbstager_Bin_v2_5_through_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Smbstager_Bin_v2_5_through_v4_x
+rule CobaltStrike_Resources_Smbstager_Bin_v2_5_through_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/smbstager.bin signature for versions 2.5 to 4.x"
-		rs1 = "946af5a23e5403ea1caccb2e0988ec1526b375a3e919189f16491eeabc3e7d8c"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/smbstager.bin signature for versions 2.5 to 4.x"
+		hash =  "946af5a23e5403ea1caccb2e0988ec1526b375a3e919189f16491eeabc3e7d8c"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	/*

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_Py_v3_3_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_Py_v3_3_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Template_Py_v3_3_to_v4_x
+rule CobaltStrike_Resources_Template_Py_v3_3_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/template.py signature for versions v3.3 to v4.x"
-		rs1 = "d5cb406bee013f51d876da44378c0a89b7b3b800d018527334ea0c5793ea4006"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/template.py signature for versions v3.3 to v4.x"
+		hash =  "d5cb406bee013f51d876da44378c0a89b7b3b800d018527334ea0c5793ea4006"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
   strings:   
     $arch = "platform.architecture()"

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_Sct_v3_3_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_Sct_v3_3_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Template_Sct_v3_3_to_v4_x
+rule CobaltStrike_Resources_Template_Sct_v3_3_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/template.sct signature for versions v3.3 to v4.x"
-		rs1 = "fc66cb120e7bc9209882620f5df7fdf45394c44ca71701a8662210cf3a40e142"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/template.sct signature for versions v3.3 to v4.x"
+		hash =  "fc66cb120e7bc9209882620f5df7fdf45394c44ca71701a8662210cf3a40e142"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
 	strings:
     $scriptletstart = "<scriptlet>" nocase

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_Vbs_v3_3_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_Vbs_v3_3_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources__Template_Vbs_v3_3_to_v4_x
+rule CobaltStrike_Resources__Template_Vbs_v3_3_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/btemplate.vbs signature for versions v3.3 to v4.x"
-		rs1 = "e0683f953062e63b2aabad7bc6d76a78748504b114329ef8e2ece808b3294135"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/btemplate.vbs signature for versions v3.3 to v4.x"
+		hash =  "e0683f953062e63b2aabad7bc6d76a78748504b114329ef8e2ece808b3294135"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	  $ea = "Excel.Application" nocase

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_Vbs_v3_3_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_Vbs_v3_3_to_v4_x.yara
@@ -32,7 +32,8 @@ rule CobaltStrike_Resources__Template_Vbs_v3_3_to_v4_x
     $regwrite = ".RegWrite" nocase
     $dw = "REG_DWORD"
     $code = ".CodeModule.AddFromString"
-    $ao = "Auto_Open"
+	 /* Hex encoded Auto_*/ /*Open */
+    $ao = { 41 75 74 6f 5f 4f 70 65 6e }
     $da = ".DisplayAlerts"
 
   condition:

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template__x32_x64_Ps1_v1_45_to_v2_5_and_v3_11_to_v3_14.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template__x32_x64_Ps1_v1_45_to_v2_5_and_v3_11_to_v3_14.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Template__x32_x64_Ps1_v1_45_to_v2_5_and_v3_11_to_v3_14
+rule CobaltStrike_Resources_Template__x32_x64_Ps1_v1_45_to_v2_5_and_v3_11_to_v3_14
 {
 	meta:
-		desc="Cobalt Strike's resources/template.x64.ps1, resources/template.x32 from v3.11 to v3.14 and resources/template.ps1 from v1.45 to v2.5 "
-		rs1 = "ff743027a6bcc0fee02107236c1f5c96362eeb91f3a5a2e520a85294741ded87"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/template.x64.ps1, resources/template.x32 from v3.11 to v3.14 and resources/template.ps1 from v1.45 to v2.5 "
+		hash =  "ff743027a6bcc0fee02107236c1f5c96362eeb91f3a5a2e520a85294741ded87"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_x64_Ps1_v3_0_to_v4_x_excluding_3_12_3_13.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_x64_Ps1_v3_0_to_v4_x_excluding_3_12_3_13.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Template_x64_Ps1_v3_0_to_v4_x_excluding_3_12_3_13
+rule CobaltStrike_Resources_Template_x64_Ps1_v3_0_to_v4_x_excluding_3_12_3_13
 {
 	meta:
-		desc="Cobalt Strike's resources/template.x64.ps1, resources/template.hint.x64.ps1 and resources/template.hint.x32.ps1 from v3.0 to v4.x except 3.12 and 3.13"
-		rs1 = "ff743027a6bcc0fee02107236c1f5c96362eeb91f3a5a2e520a85294741ded87"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/template.x64.ps1, resources/template.hint.x64.ps1 and resources/template.hint.x32.ps1 from v3.0 to v4.x except 3.12 and 3.13"
+		hash =  "ff743027a6bcc0fee02107236c1f5c96362eeb91f3a5a2e520a85294741ded87"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
     $dda = "[AppDomain]::CurrentDomain.DefineDynamicAssembly" nocase

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Template_x86_Vba_v3_8_to_v4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Template_x86_Vba_v3_8_to_v4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Template_x86_Vba_v3_8_to_v4_x
+rule CobaltStrike_Resources_Template_x86_Vba_v3_8_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resources/template.x86.vba signature for versions v3.8 to v4.x"
-		rs1 = "fc66cb120e7bc9209882620f5df7fdf45394c44ca71701a8662210cf3a40e142"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resources/template.x86.vba signature for versions v3.8 to v4.x"
+		hash =  "fc66cb120e7bc9209882620f5df7fdf45394c44ca71701a8662210cf3a40e142"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 
 	strings:
     $createstuff = "Function CreateStuff Lib \"kernel32\" Alias \"CreateRemoteThread\"" nocase

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Xor_Bin__32bit_v2_x_to_4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Xor_Bin__32bit_v2_x_to_4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Xor_Bin_v2_x_to_v4_x
+rule CobaltStrike_Resources_Xor_Bin_v2_x_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resource/xor.bin signature for version 2.x through 4.x"
-		rs1 = "211ccc5d28b480760ec997ed88ab2fbc5c19420a3d34c1df7991e65642638a6f"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resource/xor.bin signature for version 2.x through 4.x"
+		hash =  "211ccc5d28b480760ec997ed88ab2fbc5c19420a3d34c1df7991e65642638a6f"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	  /* The method for making this signatures consists of extracting each stub from the various resources/xor.bin files

--- a/YARA/CobaltStrike/CobaltStrike__Resources_Xor_Bin__64bit_v3_12_to_4_x.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Resources_Xor_Bin__64bit_v3_12_to_4_x.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Resources_Xor_Bin__64bit_v3_12_to_v4_x
+rule CobaltStrike_Resources_Xor_Bin__64bit_v3_12_to_v4_x
 {
 	meta:
-		desc="Cobalt Strike's resource/xor64.bin signature for version 3.12 through 4.x"
-		rs1 = "01dba8783768093b9a34a1ea2a20f72f29fd9f43183f3719873df5827a04b744"
-    author = "gssincla@google.com"
+		description = "Cobalt Strike's resource/xor64.bin signature for version 3.12 through 4.x"
+		hash =  "01dba8783768093b9a34a1ea2a20f72f29fd9f43183f3719873df5827a04b744"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
 		
 	strings:
 	  /* The method for making this signatures consists of extracting each stub from the various resources/xor64.bin files

--- a/YARA/CobaltStrike/CobaltStrike__Sleeve_BeaconLoader_all.yara
+++ b/YARA/CobaltStrike/CobaltStrike__Sleeve_BeaconLoader_all.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule CobaltStrike__Sleeve_BeaconLoader_HA_x86_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_HA_x86_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.HA.x86.o (HeapAlloc) Versions 4.3 through at least 4.6"
-    rs1 = "8e4a1862aa3693f0e9011ade23ad3ba036c76ae8ccfb6585dc19ceb101507dcd"
+    description = "Cobalt Strike's sleeve/BeaconLoader.HA.x86.o (HeapAlloc) Versions 4.3 through at least 4.6"
+    hash =  "8e4a1862aa3693f0e9011ade23ad3ba036c76ae8ccfb6585dc19ceb101507dcd"
     author = "gssincla@google.com"
+    reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+    date = "2022-11-18"
    
   strings:
     /*
@@ -56,12 +58,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_HA_x86_o_v4_3_v4_4_v4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_BeaconLoader_MVF_x86_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_MVF_x86_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.MVF.x86.o (MapViewOfFile) Versions 4.3 through at least 4.6"
-    rs1 = "cded3791caffbb921e2afa2de4c04546067c3148c187780066e8757e67841b44"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.MVF.x86.o (MapViewOfFile) Versions 4.3 through at least 4.6"
+    hash =  "cded3791caffbb921e2afa2de4c04546067c3148c187780066e8757e67841b44"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -107,12 +111,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_MVF_x86_o_v4_3_v4_4_v4_5_and_v4_6
 }
 
 
-rule CobaltStrike__Sleeve_BeaconLoader_VA_x86_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_VA_x86_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.VA.x86.o (VirtualAlloc) Versions 4.3 through at least 4.6"
-    rs1 = "94d1b993a9d5786e0a9b44ea1c0dc27e225c9eb7960154881715c47f9af78cc1"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.VA.x86.o (VirtualAlloc) Versions 4.3 through at least 4.6"
+    hash =  "94d1b993a9d5786e0a9b44ea1c0dc27e225c9eb7960154881715c47f9af78cc1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -187,12 +193,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_VA_x86_o_v4_3_v4_4_v4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_BeaconLoader_x86_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_x86_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.x86.o Versions 4.3 through at least 4.6"
-    rs1 = "94d1b993a9d5786e0a9b44ea1c0dc27e225c9eb7960154881715c47f9af78cc1"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.x86.o Versions 4.3 through at least 4.6"
+    hash =  "94d1b993a9d5786e0a9b44ea1c0dc27e225c9eb7960154881715c47f9af78cc1"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -270,12 +278,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_x86_o_v4_3_v4_4_v4_5_and_v4_6
 
 // 64-bit BeaconLoaders
 
-rule CobaltStrike__Sleeve_BeaconLoader_HA_x64_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_HA_x64_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.HA.x64.o (HeapAlloc) Versions 4.3 through at least 4.6"
-    rs1 = "d64f10d5a486f0f2215774e8ab56087f32bef19ac666e96c5627c70d345a354d"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.HA.x64.o (HeapAlloc) Versions 4.3 through at least 4.6"
+    hash =  "d64f10d5a486f0f2215774e8ab56087f32bef19ac666e96c5627c70d345a354d"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -313,12 +323,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_HA_x64_o_v4_3_v4_4_v4_5_and_v4_6
 }
 
 
-rule CobaltStrike__Sleeve_BeaconLoader_MVF_x64_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_MVF_x64_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.MVF.x64.o (MapViewOfFile) Versions 4.3 through at least 4.6"
-    rs1 = "9d5b6ccd0d468da389657309b2dc325851720390f9a5f3d3187aff7d2cd36594"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.MVF.x64.o (MapViewOfFile) Versions 4.3 through at least 4.6"
+    hash =  "9d5b6ccd0d468da389657309b2dc325851720390f9a5f3d3187aff7d2cd36594"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -361,12 +373,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_MVF_x64_o_v4_3_v4_4_v4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_BeaconLoader_VA_x64_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_VA_x64_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.VA.x64.o (VirtualAlloc) Versions 4.3 through at least 4.6"
-    rs1 = "ac090a0707aa5ccd2c645b523bd23a25999990cf6895fce3bfa3b025e3e8a1c9"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.VA.x64.o (VirtualAlloc) Versions 4.3 through at least 4.6"
+    hash =  "ac090a0707aa5ccd2c645b523bd23a25999990cf6895fce3bfa3b025e3e8a1c9"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*
@@ -441,12 +455,14 @@ rule CobaltStrike__Sleeve_BeaconLoader_VA_x64_o_v4_3_v4_4_v4_5_and_v4_6
     all of them
 }
 
-rule CobaltStrike__Sleeve_BeaconLoader_x64_o_v4_3_v4_4_v4_5_and_v4_6
+rule CobaltStrike_Sleeve_BeaconLoader_x64_o_v4_3_v4_4_v4_5_and_v4_6
 {
   meta:
-    desc="Cobalt Strike's sleeve/BeaconLoader.x64.o (Base) Versions 4.3 through at least 4.6"
-    rs1 = "ac090a0707aa5ccd2c645b523bd23a25999990cf6895fce3bfa3b025e3e8a1c9"
-    author = "gssincla@google.com"
+    description = "Cobalt Strike's sleeve/BeaconLoader.x64.o (Base) Versions 4.3 through at least 4.6"
+    hash =  "ac090a0707aa5ccd2c645b523bd23a25999990cf6895fce3bfa3b025e3e8a1c9"
+		author = "gssincla@google.com"
+		reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+		date = "2022-11-18"
     
   strings:
     /*

--- a/YARA/Sliver/Sliver__Implant_32bit.yara
+++ b/YARA/Sliver/Sliver__Implant_32bit.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule Sliver__Implant_32bit
+rule Sliver_Implant_32bit
 {
   meta:
-    desc = "Sliver 32-bit implant (with and without --debug flag at compile)"
-    rs1 = "911f4106350871ddb1396410d36f2d2eadac1166397e28a553b28678543a9357"
+    description = "Sliver 32-bit implant (with and without --debug flag at compile)"
+    hash =  "911f4106350871ddb1396410d36f2d2eadac1166397e28a553b28678543a9357"
     author = "gssincla@google.com"
+    reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+    date = "2022-11-18"
 
   strings:
     // We look for the specific switch/case statement case values.

--- a/YARA/Sliver/Sliver__Implant_32bit.yara
+++ b/YARA/Sliver/Sliver__Implant_32bit.yara
@@ -22,6 +22,7 @@ rule Sliver_Implant_32bit
     author = "gssincla@google.com"
     reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
     date = "2022-11-18"
+    modified = "2022-11-19"
 
   strings:
     // We look for the specific switch/case statement case values.
@@ -34,13 +35,13 @@ rule Sliver_Implant_32bit
       .
       81 ?? 04 69 76 6F 74  cmp     dword ptr [ecx+4], 746F7669h
     */
-    $tcppivot = { 81 ?? 74 63 70 70 [2-20] 81 ?? 04 69 76 6F 74  }
+    $s_tcppivot = { 81 ?? 74 63 70 70 [2-20] 81 ?? 04 69 76 6F 74  }
 
     // case "wg":
     /*
       66 81 ?? 77 67 cmp     word ptr [eax], 6777h      // "gw"
     */
-    $wg = { 66 81 ?? 77 67 }
+    $s_wg = { 66 81 ?? 77 67 }
 
     // case "dns":
     /*
@@ -50,13 +51,13 @@ rule Sliver_Implant_32bit
       .
       80 ?? 02 73    cmp     byte ptr [eax+2], 73h ; 's'
     */
-    $dns = { 66 81 ?? 64 6E [2-20] 80 ?? 02 73 }
+    $s_dns = { 66 81 ?? 64 6E [2-20] 80 ?? 02 73 }
 
     // case "http":
     /*
       81 ?? 68 74 74 70  cmp     dword ptr [eax], 70747468h     // "ptth"
      */
-    $http = { 81 ?? 68 74 74 70 }
+    $s_http = { 81 ?? 68 74 74 70 }
 
     // case "https":
     /*
@@ -66,14 +67,15 @@ rule Sliver_Implant_32bit
       .
       80 ?? 04 73        cmp     byte ptr [ecx+4], 73h ; 's'
     */
-    $https = { 81 ?? 68 74 74 70 [2-20] 80 ?? 04 73 }
+    $s_https = { 81 ?? 68 74 74 70 [2-20] 80 ?? 04 73 }
 
     // case "mtls":       NOTE: this one can be missing due to compilate time config
     /*
       81 ?? 6D 74 6C 73  cmp     dword ptr [eax], 736C746Dh     // "sltm"
     */
-    $mtls = { 81 ?? 6D 74 6C 73 }
+    $s_mtls = { 81 ?? 6D 74 6C 73 }
 
+    $fp1 = "cloudfoundry" ascii fullword
   condition:
-    4 of them
+    4 of ($s*) and not 1 of ($fp*)
 }

--- a/YARA/Sliver/Sliver__Implant_64bit.yara
+++ b/YARA/Sliver/Sliver__Implant_64bit.yara
@@ -14,12 +14,14 @@
  * limitations under the License.
  */
 
-rule Sliver__Implant_64bit
+rule Sliver_Implant_64bit
 {
   meta:
-    desc = "Sliver 64-bit implant (with and without --debug flag at compile)"
-    rs1 = "2d1c9de42942a16c88a042f307f0ace215cdc67241432e1152080870fe95ea87"
+    description = "Sliver 64-bit implant (with and without --debug flag at compile)"
+    hash =  "2d1c9de42942a16c88a042f307f0ace215cdc67241432e1152080870fe95ea87"
     author = "gssincla@google.com"
+    reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
+    date = "2022-11-18"
 
   strings:
     // We look for the specific switch/case statement case values.

--- a/YARA/Sliver/Sliver__Implant_64bit.yara
+++ b/YARA/Sliver/Sliver__Implant_64bit.yara
@@ -22,6 +22,7 @@ rule Sliver_Implant_64bit
     author = "gssincla@google.com"
     reference = "https://cloud.google.com/blog/products/identity-security/making-cobalt-strike-harder-for-threat-actors-to-abuse"
     date = "2022-11-18"
+    modified = "2022-11-19"
 
   strings:
     // We look for the specific switch/case statement case values.
@@ -30,7 +31,7 @@ rule Sliver_Implant_64bit
     /*
       48 ?? 74 63 70 70 69 76 6F 74 mov     rcx, 746F766970706374h
     */
-    $tcppivot = { 48 ?? 74 63 70 70 69 76 6F 74 }
+    $s_tcppivot = { 48 ?? 74 63 70 70 69 76 6F 74 }
 
 
     // case "namedpipe":
@@ -42,7 +43,7 @@ rule Sliver_Implant_64bit
       80 ?? 08 65 cmp     byte ptr [rdx+8], 65h ; 'e'
 
     */
-    $namedpipe = { 48 ?? 6E 61 6D 65 64 70 69 70 [2-32] 80 ?? 08 65 }
+    $s_namedpipe = { 48 ?? 6E 61 6D 65 64 70 69 70 [2-32] 80 ?? 08 65 }
 
     // case "https":
     /*
@@ -52,13 +53,13 @@ rule Sliver_Implant_64bit
       .
       80 7A 04 73       cmp     byte ptr [rdx+4], 73h ; 's'
     */
-    $https = { 81 ?? 68 74 74 70 [2-32] 80 ?? 04 73 }
+    $s_https = { 81 ?? 68 74 74 70 [2-32] 80 ?? 04 73 }
 
     // case "wg":
     /*
       66 81 3A 77 67 cmp     word ptr [rdx], 6777h      // "gw"
     */
-    $wg = {66 81 ?? 77 67}
+    $s_wg = {66 81 ?? 77 67}
 
 
     // case "dns":
@@ -69,14 +70,15 @@ rule Sliver_Implant_64bit
       .
       80 7A 02 73    cmp     byte ptr [rdx+2], 73h ; 's'
     */
-    $dns = { 66 81 ?? 64 6E [2-20] 80 ?? 02 73 }
+    $s_dns = { 66 81 ?? 64 6E [2-20] 80 ?? 02 73 }
 
     // case "mtls":         // This one may or may not be in the file, depending on the config flags.
     /*
        81 ?? 6D 74 6C 73 cmp   dword ptr [rdx], 736C746Dh          // "mtls"
     */
-    $mtls = {  81 ?? 6D 74 6C 73  }
+    $s_mtls = {  81 ?? 6D 74 6C 73  }
 
+    $fp1 = "cloudfoundry" ascii fullword
   condition:
-    5 of them
+    5 of ($s*) and not 1 of ($fp*)
 }


### PR DESCRIPTION
- I've cleaned up and extended the meta data. This PR is just an offer. Pull it if you find the changes useful. 
- I've also handled a false positive triggered by the Sliver rules on CloudFoundry clients
- I've also modified the rules so that they don't get detected and removed by Kaspersky and Avast AV engines

Sample with FPs : https://www.virustotal.com/gui/file/bab4a6db5d52a55b82cefccfa94c1a084f20d6adc7f94e9586a59919beb15185/detection